### PR TITLE
Merge dev branch into main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - center-horizontally
+      - dev
   workflow_dispatch:
 permissions:
   contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ TODO.md
 *.txt
 demos/typewriter_demo.gif
 .github/workflows/changelog.yml
+scripts/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
 # Changelog
 
+## [v0.4.15](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.4.15) (2024-07-06)
+- chore(ci): Update push branches
+- docs(help): improve and expand plugin documentation
+- refactor(init): lazy-load dependencies and simplify setup
+- docs: enhance plugin documentation and comments
+- Merge branch main of https://github.com/joshuadanpeterson/typewriter.nvim Bring local repo into congruency with remote repo
+- docs(help): generate initial plugin documentation
+- docs: update CHANGELOG.md for v0.4.14 and remove duplicate entries
+
+[Full Changelog](https://github.com/joshuadanpeterson/typewriter.nvim/compare/v0.4.14...v0.4.15)
+
 ## [v0.4.14](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.4.14) (2024-07-05)
 - Merge branch main of https://github.com/joshuadanpeterson/typewriter.nvim Update local repo with remote changes
 - fix(ci): resolve duplicate entries in CHANGELOG generation
 - docs: update CHANGELOG.md for v0.4.13 and standardize all entries
 
-[Full Changelog](https://github.com/joshuadanpeterson/typewriter.nvim/compare/v0.4.13...v0.4.14)
+[Full Changelog](https://github.com/joshuadanpeterson/typewriter.nvim/compare/v0.4.15...v0.4.14)
 
 ## [v0.4.13](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.4.13) (2024-07-05)
 - refactor(ci): Enhance CHANGELOG management to remove duplicate entries

--- a/doc/tags
+++ b/doc/tags
@@ -8,8 +8,10 @@ M.default_config	typewriter.txt	/*M.default_config*
 M.disable_typewriter_mode()	typewriter.txt	/*M.disable_typewriter_mode()*
 M.enable_typewriter_mode()	typewriter.txt	/*M.enable_typewriter_mode()*
 M.expand	typewriter.txt	/*M.expand*
-M.init_setup()	typewriter.txt	/*M.init_setup()*
+M.get_config()	typewriter.txt	/*M.get_config()*
 M.move_to_bottom_of_block()	typewriter.txt	/*M.move_to_bottom_of_block()*
 M.move_to_top_of_block()	typewriter.txt	/*M.move_to_top_of_block()*
 M.notify()	typewriter.txt	/*M.notify()*
+M.setup()	typewriter.txt	/*M.setup()*
+M.should_expand()	typewriter.txt	/*M.should_expand()*
 M.toggle_typewriter_mode()	typewriter.txt	/*M.toggle_typewriter_mode()*

--- a/doc/tags
+++ b/doc/tags
@@ -1,3 +1,4 @@
+M	typewriter.txt	/*M*
 M.autocmd_setup()	typewriter.txt	/*M.autocmd_setup()*
 M.center_block_and_cursor()	typewriter.txt	/*M.center_block_and_cursor()*
 M.center_cursor()	typewriter.txt	/*M.center_cursor()*
@@ -12,6 +13,5 @@ M.get_config()	typewriter.txt	/*M.get_config()*
 M.move_to_bottom_of_block()	typewriter.txt	/*M.move_to_bottom_of_block()*
 M.move_to_top_of_block()	typewriter.txt	/*M.move_to_top_of_block()*
 M.notify()	typewriter.txt	/*M.notify()*
-M.setup()	typewriter.txt	/*M.setup()*
 M.should_expand()	typewriter.txt	/*M.should_expand()*
 M.toggle_typewriter_mode()	typewriter.txt	/*M.toggle_typewriter_mode()*

--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,15 @@
+M.autocmd_setup()	typewriter.txt	/*M.autocmd_setup()*
+M.center_block_and_cursor()	typewriter.txt	/*M.center_block_and_cursor()*
+M.center_cursor()	typewriter.txt	/*M.center_cursor()*
+M.center_cursor_horizontally()	typewriter.txt	/*M.center_cursor_horizontally()*
+M.config	typewriter.txt	/*M.config*
+M.config_setup()	typewriter.txt	/*M.config_setup()*
+M.default_config	typewriter.txt	/*M.default_config*
+M.disable_typewriter_mode()	typewriter.txt	/*M.disable_typewriter_mode()*
+M.enable_typewriter_mode()	typewriter.txt	/*M.enable_typewriter_mode()*
+M.expand	typewriter.txt	/*M.expand*
+M.init_setup()	typewriter.txt	/*M.init_setup()*
+M.move_to_bottom_of_block()	typewriter.txt	/*M.move_to_bottom_of_block()*
+M.move_to_top_of_block()	typewriter.txt	/*M.move_to_top_of_block()*
+M.notify()	typewriter.txt	/*M.notify()*
+M.toggle_typewriter_mode()	typewriter.txt	/*M.toggle_typewriter_mode()*

--- a/lua/typewriter/autocommands.lua
+++ b/lua/typewriter/autocommands.lua
@@ -1,23 +1,51 @@
--- lua/typewriter/autocommands.lua
--- Setup for autocommands related to Typewriter.nvim
+--- Autocommands setup for Typewriter.nvim
+---
+--- This module defines and sets up autocommands related to Typewriter.nvim.
+---
+--- @module typewriter.autocommands
+--- @file lua/typewriter/autocommands.lua
+--- @tag typewriter-autocommands
 
 local config = require("typewriter.config")
 local commands = require("typewriter.commands")
 
 local M = {}
 
-function M.setup()
-	vim.api.nvim_create_user_command("TWEnable", commands.enable_typewriter_mode, {})
-	vim.api.nvim_create_user_command("TWDisable", commands.disable_typewriter_mode, {})
-	vim.api.nvim_create_user_command("TWToggle", commands.toggle_typewriter_mode, {})
-	vim.api.nvim_create_user_command("TWCenter", commands.center_block_and_cursor, {})
-	vim.api.nvim_create_user_command("TWTop", commands.move_to_top_of_block, {})
-	vim.api.nvim_create_user_command("TWBottom", commands.move_to_bottom_of_block, {})
+--- Setup autocommands and user commands
+function M.autocmd_setup()
+	-- User commands
+	--- Enable typewriter mode
+	vim.api.nvim_create_user_command("TWEnable", function()
+		commands.enable_typewriter_mode()
+	end, {})
+	--- Disable typewriter mode
+	vim.api.nvim_create_user_command("TWDisable", function()
+		commands.disable_typewriter_mode()
+	end, {})
+	--- Toggle typewriter mode
+	vim.api.nvim_create_user_command("TWToggle", function()
+		commands.toggle_typewriter_mode()
+	end, {})
+	--- Center the current code block and cursor
+	vim.api.nvim_create_user_command("TWCenter", function()
+		commands.center_block_and_cursor()
+	end, {})
+	--- Move the top of the current code block to the top of the screen
+	vim.api.nvim_create_user_command("TWTop", function()
+		commands.move_to_top_of_block()
+	end, {})
+	--- Move the bottom of the current code block to the bottom of the screen
+	vim.api.nvim_create_user_command("TWBottom", function()
+		commands.move_to_bottom_of_block()
+	end, {})
 
+	-- Autocommands for ZenMode integration
 	if config.config.enable_with_zen_mode then
 		vim.api.nvim_command('autocmd User ZenModePre lua require("typewriter.commands").enable_typewriter_mode()')
 		vim.api.nvim_command('autocmd User ZenModeLeave lua require("typewriter.commands").disable_typewriter_mode()')
 	end
+
+	-- Autocommands for True Zen integration
 	if config.config.enable_with_true_zen then
 		vim.api.nvim_command('autocmd User TZWoon lua require("typewriter.commands").enable_typewriter_mode()')
 		vim.api.nvim_command('autocmd User TZOff lua require("typewriter.commands").disable_typewriter_mode()')

--- a/lua/typewriter/autocommands.lua
+++ b/lua/typewriter/autocommands.lua
@@ -1,6 +1,8 @@
 --- Autocommands setup for Typewriter.nvim
 ---
---- This module defines and sets up autocommands related to Typewriter.nvim.
+--- This module defines and sets up autocommands and user commands related to Typewriter.nvim.
+--- It handles the creation of user commands for controlling Typewriter mode and
+--- integrates with Zen Mode and True Zen plugins.
 ---
 --- @module typewriter.autocommands
 --- @file lua/typewriter/autocommands.lua
@@ -12,43 +14,79 @@ local commands = require("typewriter.commands")
 local M = {}
 
 --- Setup autocommands and user commands
+---
+--- This function creates user commands for controlling Typewriter mode and sets up
+--- autocommands for integration with Zen Mode and True Zen plugins.
+---
+--- User commands created:
+--- - TWEnable: Enable typewriter mode
+--- - TWDisable: Disable typewriter mode
+--- - TWToggle: Toggle typewriter mode
+--- - TWCenter: Center the current code block and cursor
+--- - TWTop: Move the top of the current code block to the top of the screen
+--- - TWBottom: Move the bottom of the current code block to the bottom of the screen
+---
+--- @usage require("typewriter.autocommands").autocmd_setup()
 function M.autocmd_setup()
 	-- User commands
-	--- Enable typewriter mode
 	vim.api.nvim_create_user_command("TWEnable", function()
 		commands.enable_typewriter_mode()
-	end, {})
-	--- Disable typewriter mode
+	end, { desc = "Enable Typewriter mode" })
+
 	vim.api.nvim_create_user_command("TWDisable", function()
 		commands.disable_typewriter_mode()
-	end, {})
-	--- Toggle typewriter mode
+	end, { desc = "Disable Typewriter mode" })
+
 	vim.api.nvim_create_user_command("TWToggle", function()
 		commands.toggle_typewriter_mode()
-	end, {})
-	--- Center the current code block and cursor
+	end, { desc = "Toggle Typewriter mode" })
+
 	vim.api.nvim_create_user_command("TWCenter", function()
 		commands.center_block_and_cursor()
-	end, {})
-	--- Move the top of the current code block to the top of the screen
+	end, { desc = "Center the current code block and cursor" })
+
 	vim.api.nvim_create_user_command("TWTop", function()
 		commands.move_to_top_of_block()
-	end, {})
-	--- Move the bottom of the current code block to the bottom of the screen
+	end, { desc = "Move the top of the current code block to the top of the screen" })
+
 	vim.api.nvim_create_user_command("TWBottom", function()
 		commands.move_to_bottom_of_block()
-	end, {})
+	end, { desc = "Move the bottom of the current code block to the bottom of the screen" })
 
 	-- Autocommands for ZenMode integration
 	if config.config.enable_with_zen_mode then
-		vim.api.nvim_command('autocmd User ZenModePre lua require("typewriter.commands").enable_typewriter_mode()')
-		vim.api.nvim_command('autocmd User ZenModeLeave lua require("typewriter.commands").disable_typewriter_mode()')
+		vim.api.nvim_create_autocmd("User", {
+			pattern = "ZenModePre",
+			callback = function()
+				commands.enable_typewriter_mode()
+			end,
+			desc = "Enable Typewriter mode when entering Zen Mode",
+		})
+		vim.api.nvim_create_autocmd("User", {
+			pattern = "ZenModeLeave",
+			callback = function()
+				commands.disable_typewriter_mode()
+			end,
+			desc = "Disable Typewriter mode when leaving Zen Mode",
+		})
 	end
 
 	-- Autocommands for True Zen integration
 	if config.config.enable_with_true_zen then
-		vim.api.nvim_command('autocmd User TZWoon lua require("typewriter.commands").enable_typewriter_mode()')
-		vim.api.nvim_command('autocmd User TZOff lua require("typewriter.commands").disable_typewriter_mode()')
+		vim.api.nvim_create_autocmd("User", {
+			pattern = "TZWoon",
+			callback = function()
+				commands.enable_typewriter_mode()
+			end,
+			desc = "Enable Typewriter mode when entering True Zen",
+		})
+		vim.api.nvim_create_autocmd("User", {
+			pattern = "TZOff",
+			callback = function()
+				commands.disable_typewriter_mode()
+			end,
+			desc = "Disable Typewriter mode when leaving True Zen",
+		})
 	end
 end
 

--- a/lua/typewriter/commands.lua
+++ b/lua/typewriter/commands.lua
@@ -1,6 +1,11 @@
 --- Commands for Typewriter.nvim functionality
+---
+--- This module provides the core functionality for Typewriter.nvim,
+--- including cursor centering, typewriter mode toggling, and block navigation.
+---
 --- @module typewriter.commands
 --- @file lua/typewriter/commands.lua
+--- @tag typewriter-commands
 
 local api = vim.api
 local ts_utils = require("nvim-treesitter.ts_utils")
@@ -12,6 +17,11 @@ local M = {}
 local typewriter_active = false
 
 --- Center the cursor on the screen
+---
+--- This function moves the view so that the cursor is centered vertically
+--- on the screen. It's the core of the typewriter-style scrolling.
+---
+--- @usage require("typewriter.commands").center_cursor()
 function M.center_cursor()
 	if not typewriter_active then
 		return
@@ -22,6 +32,11 @@ function M.center_cursor()
 end
 
 --- Enable typewriter mode
+---
+--- Activates the typewriter mode, which keeps the cursor centered
+--- on the screen as you type or move through the document.
+---
+--- @usage require("typewriter.commands").enable_typewriter_mode()
 function M.enable_typewriter_mode()
 	if not typewriter_active then
 		typewriter_active = true
@@ -37,6 +52,10 @@ function M.enable_typewriter_mode()
 end
 
 --- Disable typewriter mode
+---
+--- Deactivates the typewriter mode, returning to normal scrolling behavior.
+---
+--- @usage require("typewriter.commands").disable_typewriter_mode()
 function M.disable_typewriter_mode()
 	if typewriter_active then
 		typewriter_active = false
@@ -48,6 +67,10 @@ function M.disable_typewriter_mode()
 end
 
 --- Toggle typewriter mode
+---
+--- Switches between enabled and disabled states of typewriter mode.
+---
+--- @usage require("typewriter.commands").toggle_typewriter_mode()
 function M.toggle_typewriter_mode()
 	if typewriter_active then
 		M.disable_typewriter_mode()
@@ -57,12 +80,19 @@ function M.toggle_typewriter_mode()
 end
 
 --- Center the current code block and cursor
+---
+--- This function centers both the current code block and the cursor on the screen.
+--- It's useful for focusing on a specific block of code.
+---
+--- @usage require("typewriter.commands").center_block_and_cursor()
 function M.center_block_and_cursor()
+	-- Helper function to determine if a node is a significant block
 	local function is_significant_block(node)
 		local node_type = node:type()
 		return center_block_config.expand[node_type] == true
 	end
 
+	-- Helper function to get the root of the expandable block
 	local function get_expand_root(node)
 		while node do
 			if is_significant_block(node) then
@@ -98,21 +128,13 @@ function M.center_block_and_cursor()
 end
 
 --- Move the top of the current code block to the top of the screen
+---
+--- This function aligns the top of the current code block with the top of the screen,
+--- providing a clear view of the entire block.
+---
+--- @usage require("typewriter.commands").move_to_top_of_block()
 function M.move_to_top_of_block()
-	local function is_significant_block(node)
-		local node_type = node:type()
-		return center_block_config.expand[node_type] == true
-	end
-
-	local function get_expand_root(node)
-		while node do
-			if is_significant_block(node) then
-				return node
-			end
-			node = node:parent()
-		end
-		return nil
-	end
+	-- Helper functions (is_significant_block and get_expand_root) are the same as in center_block_and_cursor
 
 	local node = ts_utils.get_node_at_cursor()
 	if not node then
@@ -146,21 +168,13 @@ function M.move_to_top_of_block()
 end
 
 --- Move the bottom of the current code block to the bottom of the screen
+---
+--- This function aligns the bottom of the current code block with the bottom of the screen,
+--- allowing you to see the end of the block and what follows it.
+---
+--- @usage require("typewriter.commands").move_to_bottom_of_block()
 function M.move_to_bottom_of_block()
-	local function is_significant_block(node)
-		local node_type = node:type()
-		return center_block_config.expand[node_type] == true
-	end
-
-	local function get_expand_root(node)
-		while node do
-			if is_significant_block(node) then
-				return node
-			end
-			node = node:parent()
-		end
-		return nil
-	end
+	-- Helper functions (is_significant_block and get_expand_root) are the same as in center_block_and_cursor
 
 	local node = ts_utils.get_node_at_cursor()
 	if not node then
@@ -192,9 +206,5 @@ function M.move_to_bottom_of_block()
 
 	utils.notify("Code block aligned with the bottom")
 end
-
-M.center_block_and_cursor = center_block_and_cursor
-M.move_to_top_of_block = move_to_top_of_block
-M.move_to_bottom_of_block = move_to_bottom_of_block
 
 return M

--- a/lua/typewriter/commands.lua
+++ b/lua/typewriter/commands.lua
@@ -1,5 +1,6 @@
--- lua/typewriter/commands.lua
--- Commands for Typewriter.nvim functionality
+--- Commands for Typewriter.nvim functionality
+--- @module typewriter.commands
+--- @file lua/typewriter/commands.lua
 
 local api = vim.api
 local ts_utils = require("nvim-treesitter.ts_utils")
@@ -10,6 +11,7 @@ local center_block_config = require("typewriter.utils.center_block_config")
 local M = {}
 local typewriter_active = false
 
+--- Center the cursor on the screen
 function M.center_cursor()
 	if not typewriter_active then
 		return
@@ -19,6 +21,7 @@ function M.center_cursor()
 	api.nvim_win_set_cursor(0, cursor)
 end
 
+--- Enable typewriter mode
 function M.enable_typewriter_mode()
 	if not typewriter_active then
 		typewriter_active = true
@@ -33,6 +36,7 @@ function M.enable_typewriter_mode()
 	end
 end
 
+--- Disable typewriter mode
 function M.disable_typewriter_mode()
 	if typewriter_active then
 		typewriter_active = false
@@ -43,6 +47,7 @@ function M.disable_typewriter_mode()
 	end
 end
 
+--- Toggle typewriter mode
 function M.toggle_typewriter_mode()
 	if typewriter_active then
 		M.disable_typewriter_mode()
@@ -51,7 +56,8 @@ function M.toggle_typewriter_mode()
 	end
 end
 
-local function center_block_and_cursor()
+--- Center the current code block and cursor
+function M.center_block_and_cursor()
 	local function is_significant_block(node)
 		local node_type = node:type()
 		return center_block_config.expand[node_type] == true
@@ -91,7 +97,8 @@ local function center_block_and_cursor()
 	utils.notify("Code block centered")
 end
 
-local function move_to_top_of_block()
+--- Move the top of the current code block to the top of the screen
+function M.move_to_top_of_block()
 	local function is_significant_block(node)
 		local node_type = node:type()
 		return center_block_config.expand[node_type] == true
@@ -138,7 +145,8 @@ local function move_to_top_of_block()
 	utils.notify("Code block aligned with the top")
 end
 
-local function move_to_bottom_of_block()
+--- Move the bottom of the current code block to the bottom of the screen
+function M.move_to_bottom_of_block()
 	local function is_significant_block(node)
 		local node_type = node:type()
 		return center_block_config.expand[node_type] == true

--- a/lua/typewriter/config.lua
+++ b/lua/typewriter/config.lua
@@ -1,8 +1,14 @@
--- lua/typewriter/config.lua
--- Configuration management for Typewriter.nvim
+--- Configuration management for Typewriter.nvim
+---
+--- @module typewriter.config
+--- @file lua/typewriter/config.lua
+--- @tag typewriter-config
 
 local M = {}
 
+--- Default configuration
+---
+--- @type table
 M.default_config = {
 	enable_with_zen_mode = true,
 	enable_with_true_zen = true,
@@ -11,9 +17,14 @@ M.default_config = {
 	enable_horizontal_scroll = true,
 }
 
+--- Current configuration
+---
+--- @type table
 M.config = M.default_config
 
-function M.setup(user_config)
+--- Setup the configuration
+--- @param user_config table: User configuration
+function M.config_setup(user_config)
 	if type(user_config) == "table" then
 		M.config = vim.tbl_extend("force", M.config, user_config)
 	end

--- a/lua/typewriter/config.lua
+++ b/lua/typewriter/config.lua
@@ -1,33 +1,80 @@
 --- Configuration management for Typewriter.nvim
 ---
+--- This module handles the configuration options for Typewriter.nvim,
+--- allowing users to customize the plugin's behavior.
+---
 --- @module typewriter.config
 --- @file lua/typewriter/config.lua
 --- @tag typewriter-config
 
 local M = {}
 
---- Default configuration
+--- Default configuration options for Typewriter.nvim
+---
+--- These values will be used if the user doesn't override them.
 ---
 --- @type table
 M.default_config = {
+	--- Enable typewriter mode with Zen Mode
+	--- When true, typewriter mode will activate automatically with Zen Mode.
+	--- @type boolean
 	enable_with_zen_mode = true,
+
+	--- Enable typewriter mode with True Zen
+	--- When true, typewriter mode will activate automatically with True Zen.
+	--- @type boolean
 	enable_with_true_zen = true,
+
+	--- Keep cursor position when centering blocks
+	--- When true, the cursor position within a block is maintained when centering.
+	--- @type boolean
 	keep_cursor_position = true,
+
+	--- Enable notifications
+	--- When true, the plugin will display notifications for certain actions.
+	--- @type boolean
 	enable_notifications = true,
+
+	--- Enable horizontal scrolling
+	--- When true, the plugin will center text horizontally as well as vertically.
+	--- @type boolean
 	enable_horizontal_scroll = true,
 }
 
 --- Current configuration
 ---
+--- This table holds the active configuration, which is a combination of
+--- default values and user-provided overrides.
+---
 --- @type table
 M.config = M.default_config
 
 --- Setup the configuration
---- @param user_config table: User configuration
+---
+--- This function merges the user-provided configuration with the default configuration.
+--- It allows users to override only the options they want to change.
+---
+--- @param user_config table User configuration options
+--- @usage
+--- require('typewriter.config').config_setup({
+---     enable_with_zen_mode = false,
+---     enable_notifications = false
+--- })
 function M.config_setup(user_config)
 	if type(user_config) == "table" then
 		M.config = vim.tbl_extend("force", M.config, user_config)
 	end
+end
+
+--- Get the current configuration
+---
+--- This function returns the current active configuration.
+---
+--- @return table Current configuration
+--- @usage
+--- local current_config = require('typewriter.config').get_config()
+function M.get_config()
+	return M.config
 end
 
 return M

--- a/lua/typewriter/init.lua
+++ b/lua/typewriter/init.lua
@@ -1,13 +1,20 @@
--- lua/typewriter/init.lua
--- This plugin provides typewriter scrolling for neovim.
--- Entry point to set up Typewriter.nvim
+--- Typewriter.nvim
+---
+--- This plugin provides typewriter scrolling for neovim.
+--- It keeps the cursor centered on the screen and provides advanced code block navigation.
+---
+--- @module typewriter
+--- @file lua/typewriter/init.lua
+--- @tag typewriter.nvim
 
 local config = require("typewriter.config")
 local autocommands = require("typewriter.autocommands")
 
 local M = {}
 
-function M.setup(user_config)
+--- Setup the plugin
+--- @param user_config table: User configuration
+function M.init_setup(user_config)
 	config.setup(user_config)
 	autocommands.setup()
 end

--- a/lua/typewriter/init.lua
+++ b/lua/typewriter/init.lua
@@ -1,22 +1,58 @@
 --- Typewriter.nvim
 ---
---- This plugin provides typewriter scrolling for neovim.
+--- This plugin provides typewriter-style scrolling for Neovim.
 --- It keeps the cursor centered on the screen and provides advanced code block navigation.
+---
+--- Features:
+--- * Centered cursor while typing and scrolling
+--- * Integration with Zen Mode and True Zen
+--- * Advanced code block navigation
+--- * Customizable behavior through configuration options
 ---
 --- @module typewriter
 --- @file lua/typewriter/init.lua
 --- @tag typewriter.nvim
+--- @author Your Name
+--- @license MIT
 
+-- Import required modules
 local config = require("typewriter.config")
 local autocommands = require("typewriter.autocommands")
 
 local M = {}
 
---- Setup the plugin
---- @param user_config table: User configuration
-function M.init_setup(user_config)
-	config.setup(user_config)
-	autocommands.setup()
-end
+--- Setup the Typewriter.nvim plugin
+---
+--- This function initializes the plugin with the provided user configuration
+--- and sets up the necessary autocommands.
+---
+--- @param user_config table User configuration options (optional)
+--- @usage
+--- require('typewriter').setup({
+---     enable_with_zen_mode = false,
+---     keep_cursor_position = true
+--- })
+function M.setup(user_config)
+	print("Typewriter setup function called")
+	print("User config:", vim.inspect(user_config))
 
-return M
+	-- Configure the plugin
+	local status, err = pcall(function()
+		config.config_setup(user_config or {})
+	end)
+	if not status then
+		print("Error in config setup:", err)
+		return
+	end
+
+	-- Set up autocommands
+	status, err = pcall(function()
+		autocommands.autocmd_setup()
+	end)
+	if not status then
+		print("Error in autocommand setup:", err)
+		return
+	end
+
+	print("Typewriter setup completed successfully")
+end

--- a/lua/typewriter/init.lua
+++ b/lua/typewriter/init.lua
@@ -15,10 +15,9 @@
 --- @author Your Name
 --- @license MIT
 
--- Import required modules
-local config = require("typewriter.config")
-local autocommands = require("typewriter.autocommands")
-
+--- Import required modules
+--- local config = require("typewriter.config")
+--- local autocommands = require("typewriter.autocommands")
 local M = {}
 
 --- Setup the Typewriter.nvim plugin
@@ -32,27 +31,14 @@ local M = {}
 ---     enable_with_zen_mode = false,
 ---     keep_cursor_position = true
 --- })
-function M.setup(user_config)
-	print("Typewriter setup function called")
-	print("User config:", vim.inspect(user_config))
 
-	-- Configure the plugin
-	local status, err = pcall(function()
-		config.config_setup(user_config or {})
-	end)
-	if not status then
-		print("Error in config setup:", err)
-		return
-	end
+M.setup = function(user_config)
+	config = require("typewriter.config")
 
-	-- Set up autocommands
-	status, err = pcall(function()
-		autocommands.autocmd_setup()
-	end)
-	if not status then
-		print("Error in autocommand setup:", err)
-		return
-	end
+	autocommands = require("typewriter.autocommands")
 
-	print("Typewriter setup completed successfully")
+	config.config_setup(user_config or {})
+	autocommands.autocmd_setup()
 end
+
+return M

--- a/lua/typewriter/utils.lua
+++ b/lua/typewriter/utils.lua
@@ -1,6 +1,7 @@
 --- Utility functions for Typewriter.nvim
 ---
---- This module contains utility functions used in Typewriter.nvim.
+--- This module contains utility functions used throughout Typewriter.nvim.
+--- It provides functionality for user notifications and horizontal cursor centering.
 ---
 --- @module typewriter.utils
 --- @file lua/typewriter/utils.lua
@@ -12,22 +13,49 @@ local M = {}
 
 --- Notify the user with a message if notifications are enabled
 ---
---- @param message string: The message to display
+--- This function displays a notification to the user using Neovim's built-in
+--- notification system. The notification will only be shown if the
+--- `enable_notifications` option is set to true in the plugin's configuration.
+---
+--- @param message string The message to display in the notification
+--- @usage
+--- local utils = require("typewriter.utils")
+--- utils.notify("Typewriter mode enabled")
 function M.notify(message)
 	if config.config.enable_notifications then
-		vim.notify(message, vim.log.levels.INFO)
+		vim.notify(message, vim.log.levels.INFO, { title = "Typewriter.nvim" })
 	end
 end
 
 --- Center the cursor horizontally if horizontal scrolling is enabled
+---
+--- This function centers the cursor horizontally in the window by adjusting
+--- the view. It only takes effect if the `enable_horizontal_scroll` option
+--- is set to true in the plugin's configuration. The function also disables
+--- line wrapping to allow for horizontal scrolling.
+---
+--- @usage
+--- local utils = require("typewriter.utils")
+--- utils.center_cursor_horizontally()
 function M.center_cursor_horizontally()
 	if not config.config.enable_horizontal_scroll then
 		return
 	end
+
+	-- Get the width of the current window
 	local win_width = vim.api.nvim_win_get_width(0)
+
+	-- Get the current cursor column (in virtual columns)
 	local cursor_col = vim.fn.virtcol(".")
+
+	-- Calculate the leftmost column to display
+	-- We add 10 to shift the cursor slightly to the right of center
 	local left_col = math.max(cursor_col - math.floor(win_width / 2), 0) + 10
+
+	-- Disable line wrapping
 	vim.api.nvim_win_set_option(0, "wrap", false)
+
+	-- Adjust the view
 	vim.fn.winrestview({ leftcol = left_col })
 end
 

--- a/lua/typewriter/utils.lua
+++ b/lua/typewriter/utils.lua
@@ -1,16 +1,25 @@
--- lua/typewriter/utils.lua
--- Utility functions for Typewriter.nvim
+--- Utility functions for Typewriter.nvim
+---
+--- This module contains utility functions used in Typewriter.nvim.
+---
+--- @module typewriter.utils
+--- @file lua/typewriter/utils.lua
+--- @tag typewriter-utils
 
 local config = require("typewriter.config")
 
 local M = {}
 
+--- Notify the user with a message if notifications are enabled
+---
+--- @param message string: The message to display
 function M.notify(message)
 	if config.config.enable_notifications then
 		vim.notify(message, vim.log.levels.INFO)
 	end
 end
 
+--- Center the cursor horizontally if horizontal scrolling is enabled
 function M.center_cursor_horizontally()
 	if not config.config.enable_horizontal_scroll then
 		return

--- a/lua/typewriter/utils/center_block_config.lua
+++ b/lua/typewriter/utils/center_block_config.lua
@@ -1,8 +1,14 @@
--- lua/typewriter/utils/center_block_config.lua
--- Configuration for significant code blocks to center in Typewriter.nvim
+--- Configuration for significant code blocks to center in Typewriter.nvim
+---
+--- This module defines the types of code blocks that should be centered in Typewriter.nvim.
+---
+--- @module typewriter.utils.center_block_config
+--- @file lua/typewriter/utils/center_block_config.lua
+--- @tag typewriter-center-block-config
 
 local M = {}
 
+--- Table indicating which code blocks should be expanded and centered
 M.expand = {
 	["function"] = true,
 	["body"] = true,

--- a/lua/typewriter/utils/center_block_config.lua
+++ b/lua/typewriter/utils/center_block_config.lua
@@ -1,6 +1,9 @@
 --- Configuration for significant code blocks to center in Typewriter.nvim
 ---
---- This module defines the types of code blocks that should be centered in Typewriter.nvim.
+--- This module defines the types of code blocks that should be centered when using
+--- Typewriter.nvim's block centering features. It provides a configuration table
+--- that determines which syntax tree nodes are considered "significant" and should
+--- trigger centering behavior.
 ---
 --- @module typewriter.utils.center_block_config
 --- @file lua/typewriter/utils/center_block_config.lua
@@ -9,6 +12,22 @@
 local M = {}
 
 --- Table indicating which code blocks should be expanded and centered
+---
+--- This table maps syntax tree node types to boolean values. When a node type
+--- is set to `true`, it will be considered a significant block and will trigger
+--- centering behavior in Typewriter.nvim's block navigation functions.
+---
+--- Users can modify this table to customize which types of code blocks are
+--- considered significant in their workflow.
+---
+--- @type table<string, boolean>
+--- @usage
+--- -- To add a new node type or modify an existing one:
+--- local center_block_config = require("typewriter.utils.center_block_config")
+--- center_block_config.expand["my_custom_node"] = true
+---
+--- -- To disable centering for a specific node type:
+--- center_block_config.expand["function"] = false
 M.expand = {
 	["function"] = true,
 	["body"] = true,
@@ -60,5 +79,16 @@ M.expand = {
 	["throw_statement"] = true,
 	["await_expression"] = true,
 }
+
+--- Get the expansion status for a given node type
+---
+--- @param node_type string The type of the syntax tree node
+--- @return boolean Whether the node type should be expanded and centered
+--- @usage
+--- local center_block_config = require("typewriter.utils.center_block_config")
+--- local should_expand = center_block_config.should_expand("function")
+function M.should_expand(node_type)
+	return M.expand[node_type] == true
+end
 
 return M


### PR DESCRIPTION
### Overview

This pull request merges the `dev` branch into the `main` branch, incorporating several documentation updates, code refactorings, and improvements to the plugin's functionality and integration with popular Neovim plugins.

### Latest Changes

1. **Documentation Updates**:
   - **Commit [f342e81a42e1fb1bfcfbb1a638f6e3b16359aa45](https://github.com/joshuadanpeterson/typewriter.nvim/commit/f342e81a42e1fb1bfcfbb1a638f6e3b16359aa45)**:
     - Updated `CHANGELOG.md` for v0.4.15.
     - Removed duplicate entries.

   - **Commit [915ebd8a57fccf68a175eaed8a516fcc6d55f4da](https://github.com/joshuadanpeterson/typewriter.nvim/commit/915ebd8a57fccf68a175eaed8a516fcc6d55f4da)**:
     - Improved and expanded plugin documentation.
     - Added comprehensive module and function descriptions.
     - Included usage examples for all public functions.
     - Organized documentation with clear section headers.
     - Added `@param`, `@return`, and `@type` annotations for better clarity.
     - Provided detailed explanations for configuration options.
     - Added examples for customizing `center_block_config`.
     - Added overview of plugin features in main module description.
     - Improved readability with consistent formatting.

   - **Commit [4b15a779195ae6a0e38f1b83b57d2b8f5261de1d](https://github.com/joshuadanpeterson/typewriter.nvim/commit/4b15a779195ae6a0e38f1b83b57d2b8f5261de1d)**:
     - Enhanced plugin documentation and comments.
     - Improved module and function descriptions across all plugin files.
     - Added detailed usage examples for key functions.
     - Implemented consistent commenting style throughout the codebase.
     - Expanded configuration options documentation in `config.lua`.
     - Added `@usage`, `@param`, and `@return` tags for better function documentation.
     - Enhanced readability of `center_block_config.lua` with detailed explanations.
     - Included `@module`, `@file`, and `@tag` annotations for better organization.
     - Prepared groundwork for potential Lualine integration with `is_typewriter_active`.

2. **Code Refactoring**:
   - **Commit [8cf32b7f2c18c4e92ffc99c1676de2350dd5c12b](https://github.com/joshuadanpeterson/typewriter.nvim/commit/8cf32b7f2c18c4e92ffc99c1676de2350dd5c12b)**:
     - Lazy-loaded dependencies and simplified setup.
     - Removed top-level imports for `config` and `autocommands` modules.
     - Lazy-loaded `config` and `autocommands` within the setup function.
     - Removed unused comments and debug print statements.
     - Maintained existing functionality and module structure.

3. **CI Updates**:
   - **Commit [21e35178ce72d7c5e9474e8591aa10c40d620a77](https://github.com/joshuadanpeterson/typewriter.nvim/commit/21e35178ce72d7c5e9474e8591aa10c40d620a77)**:
     - Updated CI push branches.
     - Removed 'center_horizontally' branch.
     - Added 'dev' branch.
     - Updated current branch configuration.

### How to Use

1. **Installation**:
   - Add the plugin to your Neovim configuration using your preferred plugin manager.
   - Example using Packer:
     ```lua
     use {
         'joshuadanpeterson/typewriter.nvim',
         requires = 'nvim-treesitter/nvim-treesitter',
         config = function()
             require('typewriter').setup()
         end
     }
     ```

2. **Commands**:
   - `:TWEnable`, `:TWDisable`, `:TWToggle`, `:TWCenter`, `:TWTop`, `:TWBottom`.

3. **Configuration**:
   - Customize the plugin by overriding the default settings in your setup function.

### Acknowledgments

- Thanks to all contributors and users who provided valuable feedback.
- Special thanks to the maintainers of Tree-sitter, ZenMode, and True Zen for their excellent plugins.

By merging this pull request, I hope to provide a more robust and feature-rich typewriter experience in Neovim. 