### PR TITLE
Fix for 'attempt to call global 'get_expand_root' (a nil value)' Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## [v0.4.22](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.4.22) (2024-07-19)
+- fix(commands): Move helper functions outside specific functions to avoid nil error
+- docs: update CHANGELOG.md for v0.4.21 and remove duplicate entries
+
+[Full Changelog](https://github.com/joshuadanpeterson/typewriter.nvim/compare/v0.4.21...v0.4.22)
+
 ## [v0.4.21](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.4.21) (2024-07-18)
 - Merge pull request #10 from joshuadanpeterson/dev
 - docs: update CHANGELOG.md for v0.4.20 and remove duplicate entries
 
-[Full Changelog](https://github.com/joshuadanpeterson/typewriter.nvim/compare/v0.4.20...v0.4.21)
+[Full Changelog](https://github.com/joshuadanpeterson/typewriter.nvim/compare/v0.4.22...v0.4.21)
 
 ## [v0.4.20](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.4.20) (2024-07-18)
 - Merge branch dev of https://github.com/joshuadanpeterson/typewriter.nvim into dev

--- a/lua/typewriter/commands.lua
+++ b/lua/typewriter/commands.lua
@@ -16,6 +16,23 @@ local center_block_config = require("typewriter.utils.center_block_config")
 local M = {}
 local typewriter_active = false
 
+--- Helper function to determine if a node is a significant block
+local function is_significant_block(node)
+	local node_type = node:type()
+	return center_block_config.expand[node_type] == true
+end
+
+--- Helper function to get the root of the expandable block
+local function get_expand_root(node)
+	while node do
+		if is_significant_block(node) then
+			return node
+		end
+		node = node:parent()
+	end
+	return nil
+end
+
 --- Center the cursor on the screen
 ---
 --- This function moves the view so that the cursor is centered vertically
@@ -76,6 +93,7 @@ function M.toggle_typewriter_mode()
 		M.enable_typewriter_mode()
 	end
 end
+
 --- Center the current code block and cursor
 ---
 --- This function centers both the current code block and the cursor on the screen.
@@ -83,23 +101,6 @@ end
 ---
 --- @usage require("typewriter.commands").center_block_and_cursor()
 function M.center_block_and_cursor()
-	-- Helper function to determine if a node is a significant block
-	local function is_significant_block(node)
-		local node_type = node:type()
-		return center_block_config.expand[node_type] == true
-	end
-
-	-- Helper function to get the root of the expandable block
-	local function get_expand_root(node)
-		while node do
-			if is_significant_block(node) then
-				return node
-			end
-			node = node:parent()
-		end
-		return nil
-	end
-
 	local node = ts_utils.get_node_at_cursor()
 	if not node then
 		return
@@ -131,8 +132,6 @@ end
 ---
 --- @usage require("typewriter.commands").move_to_top_of_block()
 function M.move_to_top_of_block()
-	-- Helper functions (is_significant_block and get_expand_root) are the same as in center_block_and_cursor
-
 	local node = ts_utils.get_node_at_cursor()
 	if not node then
 		return
@@ -171,8 +170,6 @@ end
 ---
 --- @usage require("typewriter.commands").move_to_bottom_of_block()
 function M.move_to_bottom_of_block()
-	-- Helper functions (is_significant_block and get_expand_root) are the same as in center_block_and_cursor
-
 	local node = ts_utils.get_node_at_cursor()
 	if not node then
 		return


### PR DESCRIPTION
### Description
This PR addresses the error attempt to call global 'get_expand_root' (a nil value) encountered when running the TWTop or TWBottom commands. The error occurred because the get_expand_root function was defined locally within the center_block_and_cursor function, making it unavailable to other functions like move_to_top_of_block and move_to_bottom_of_block.

### Changes Made
Moved the is_significant_block and get_expand_root helper functions outside of the specific functions, defining them at the top of commands.lua to ensure they are globally accessible within the module.
Updated the center_block_and_cursor, move_to_top_of_block, and move_to_bottom_of_block functions to use the globally defined get_expand_root function.
### Impact
This change ensures that the get_expand_root function is accessible to all functions that need it, preventing the nil value error and improving the reliability of the TWTop and TWBottom commands.
Enhances the modularity and maintainability of the code by properly organizing helper functions.
### Testing
Verified that the TWTop and TWBottom commands now execute without errors.
Ensured that the center_block_and_cursor function continues to work as expected with the refactored helper functions.
### Additional Notes
No changes were made to the existing functionality or logic of the helper functions. They were simply relocated to be globally accessible.

### Issue Reference
Closes [#8](https://github.com/joshuadanpeterson/typewriter.nvim/issues/8)