### PR TITLE
Preserve Column Position When Moving Between Lines of Different Lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
+## [v0.6.4](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.6.4) (2024-07-21)
+- docs: update CHANGELOG.md for v0.6.3 and remove duplicate entries
+
+[Full Changelog](https://github.com/joshuadanpeterson/typewriter.nvim/compare/v0.6.3...v0.6.4)
+
 ## [v0.6.3](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.6.3) (2024-07-21)
 - Merge pull request #15 from joshuadanpeterson/dev
 - docs: update CHANGELOG.md for v0.6.2 and remove duplicate entries
 
-[Full Changelog](https://github.com/joshuadanpeterson/typewriter.nvim/compare/v0.6.2...v0.6.3)
+[Full Changelog](https://github.com/joshuadanpeterson/typewriter.nvim/compare/v0.6.4...v0.6.3)
 
 ## [v0.6.2](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.6.2) (2024-07-21)
 - Merge branch 'main' into dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
+## [v0.6.5](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.6.5) (2024-07-29)
+- feat(autocommands): Preserve column position when moving between lines of different lengths
+- docs: update CHANGELOG.md for v0.6.4 and remove duplicate entries
+
+[Full Changelog](https://github.com/joshuadanpeterson/typewriter.nvim/compare/v0.6.4...v0.6.5)
+
 ## [v0.6.4](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.6.4) (2024-07-21)
 - docs: update CHANGELOG.md for v0.6.3 and remove duplicate entries
 
-[Full Changelog](https://github.com/joshuadanpeterson/typewriter.nvim/compare/v0.6.3...v0.6.4)
+[Full Changelog](https://github.com/joshuadanpeterson/typewriter.nvim/compare/v0.6.5...v0.6.4)
 
 ## [v0.6.3](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.6.3) (2024-07-21)
 - Merge pull request #15 from joshuadanpeterson/dev


### PR DESCRIPTION
## Description:

This pull request introduces a new feature to preserve the cursor's column position when navigating between lines of varying lengths in Neovim. The change addresses the issue where the cursor position would reset or not be preserved correctly when moving between lines, particularly handling edge cases such as blank lines and shorter lines.

## Changes Made:

1. **New Autocommand**:
   - Added a `CursorMoved` autocommand to handle cursor position preservation.
   - The autocommand is triggered whenever the cursor is moved, ensuring real-time adjustment of the cursor position.

2. **Target Column Management**:
   - Introduced `target_col` to store the desired column position across line movements.
   - The `target_col` is initially set to the current column when moving to a new line and updated when moving within the same line.

3. **Line Length Handling**:
   - If the new line is shorter than `target_col`, the cursor is moved to the end of the line.
   - If the new line is long enough, the cursor is moved to `target_col`.

4. **Lateral Movements**:
   - Ensured that lateral movements (`h`, `l`) within the same line update the `target_col` correctly, preserving the cursor's horizontal position.

5. **Blank Lines**:
   - Correctly managed cursor position for blank lines, ensuring it does not reset to 0 unexpectedly.

6. **Cursor Centering**:
   - Called `commands.center_cursor()` after each movement to keep the cursor centered, enhancing the user experience.

## Fixes Issue:
This PR fixes issue #16 where:

When moving between lines with j and k, if the next line is shorter than the current column, the cursor moves to the end of the line.

When moving to the next line, which has enough columns for the original cursor position, Vim sets it to that column instead of the max length of the previous line.

Broken Step: When moving back to the original line, the cursor was incorrectly set, leading to an unexpected cursor path.

This change ensures the cursor maintains the correct column position as expected, preserving the original column when moving between lines of different lengths.

## Example Code:

```lua
-- lua/typewriter/autocommands.lua
-- Preserve column position when moving between lines of different lengths
local target_col = nil
local last_line = nil

vim.api.nvim_create_autocmd("CursorMoved", {
  pattern = "*",
  callback = function()
    local current_line, current_col = unpack(vim.api.nvim_win_get_cursor(0))
    local line_length = vim.fn.col('$') - 1 -- Get the actual length of the current line

    -- If we've moved to a new line
    if last_line ~= current_line then
      -- If target_col is not set, use the current column
      if target_col == nil then
        target_col = current_col
      end

      -- If the current line is shorter than target_col, move to the end of the line
      if line_length < target_col then
        vim.api.nvim_win_set_cursor(0, { current_line, line_length })
      -- If the current line is long enough, move to the target column
      elseif current_col ~= target_col then
        vim.api.nvim_win_set_cursor(0, { current_line, target_col })
      end
    else
      -- If we're on the same line, update the target column
      target_col = current_col
    end

    last_line = current_line

    -- Center the cursor
    commands.center_cursor()
  end
})
```

## Benefits:

- **Improved User Experience**: The cursor now maintains its horizontal position when navigating through lines, providing a more intuitive and consistent experience.
- **Enhanced Readability**: Users can now easily move between lines without losing their cursor's position, making code navigation and editing more efficient.

## Testing:

- Tested with various line lengths, including shorter lines, longer lines, and blank lines, to ensure the cursor position is preserved correctly.
- Verified lateral movements within the same line update the `target_col` appropriately.
- Confirmed the cursor remains centered after each movement.