### PR TITLE
fix(autocommands): Correct column preservation behavior in TWDisable

### DIFF
--- a/lua/typewriter/autocommands.lua
+++ b/lua/typewriter/autocommands.lua
@@ -226,8 +226,21 @@ function M.autocmd_setup()
 	end, { desc = "Enable Typewriter mode" })
 
 	vim.api.nvim_create_user_command("TWDisable", function()
+		-- Disable typewriter mode
 		commands.disable_typewriter_mode()
-	end, { desc = "Disable Typewriter mode" })
+
+		-- Check if column preservation is active, and reset state to NORMAL
+		if current_state == State.PRESERVE_COLUMN then
+			set_state(State.NORMAL)
+			print("Column preservation disabled")
+		end
+
+		-- Clear any autocmds related to column preservation or cursor movement
+		vim.api.nvim_clear_autocmds({
+			event = "CursorMoved",
+			buffer = 0, -- for the current buffer
+		})
+	end, { desc = "Disable Typewriter mode and column preservation" })
 
 	vim.api.nvim_create_user_command("TWToggle", function()
 		commands.toggle_typewriter_mode()


### PR DESCRIPTION
**Description:**
This pull request addresses an issue where the TWDisable command failed to fully disable column preservation, leading to unintended modifications of the cursor column after running the command. This fix ensures that the autocmd responsible for column preservation is correctly cleared when TWDisable is executed.

**Changes:**
Added a check within TWDisable to detect if column preservation is active and reset the state to NORMAL.
Included logic to clear any CursorMoved autocmds that might interfere with cursor behavior after disabling typewriter mode.
Provided feedback through a message indicating that column preservation has been disabled.

**Testing:**
Tested the TWDisable command to verify that column preservation is fully deactivated after use.
Ensured that all related autocmds are cleared, and the cursor behaves as expected without column modifications.

**Related Issues:**
Resolves [Issue #20](https://github.com/joshuadanpeterson/typewriter.nvim/issues/20): TWDisable doesn’t disable the autocmd that modifies the column.