### PR TITLE
fix(autocommands): Add missing utils import

### DIFF
--- a/lua/typewriter/autocommands.lua
+++ b/lua/typewriter/autocommands.lua
@@ -8,6 +8,7 @@ local config = require("typewriter.config")
 local commands = require("typewriter.commands")
 local ts_utils = require('nvim-treesitter.ts_utils')
 local ts_parsers = require('nvim-treesitter.parsers')
+local utils = require('typewriter.utils')
 
 local M = {}
 


### PR DESCRIPTION
I noticed there was a missing `utils` import in the `autocommands` file. I'm not 100% sure why I stumbled upon this (what edge case I encountered while using the plugin).

The problem is at [line 281 in this PR](https://github.com/sabinmarcu/typewriter.nvim/blob/041215bbc29767789ba03288669356ba9772ac32/lua/typewriter/autocommands.lua#L281) (280 in the original)

Hope this helps, and mandatory: awesome work with the plugin 🙏 ❤️ 