### PR TITLE
Add start_enabled option for automatic startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [v0.7.1](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.7.1) (2025-06-16)
+- feat(config): add `start_enabled` option to enable plugin on startup (#29)
+
 
 ## [v0.7.0](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.7.0) (2025-06-16)
 - Merge pull request #39 from joshuadanpeterson/codex/create-tests-folder-and-add-tests

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ require('packer').startup(function()
                 keep_cursor_position = true,
                 enable_notifications = true,
                 enable_horizontal_scroll = true,
+                start_enabled = false,
             })
         end
     }
@@ -269,6 +270,7 @@ lazy.setup({
                 keep_cursor_position = true,
                 enable_notifications = true,
                 enable_horizontal_scroll = true,
+                start_enabled = false,
             })
         end,
         opts = {}

--- a/doc/typewriter.txt
+++ b/doc/typewriter.txt
@@ -246,6 +246,7 @@ and sets up the necessary autocommands.
 require('typewriter').setup({
     enable_with_zen_mode = false,
     keep_cursor_position = true
+    start_enabled = false
 })
 
 
@@ -335,6 +336,10 @@ The screen is redrawn after adjusting the view to avoid ghost text.
 @usage
 local utils = require("typewriter.utils")
 utils.center_cursor_horizontally()
+
+Starting Typewriter mode automatically
+  Set `start_enabled` to `true` in `require('typewriter').setup()` to have the plugin
+  enable typewriter mode on startup.
 
 ------------------------------------------------------------------------------
                                                       *M.is_typewriter_active()*

--- a/lua/typewriter/config.lua
+++ b/lua/typewriter/config.lua
@@ -35,10 +35,15 @@ M.default_config = {
 	--- @type boolean
 	enable_notifications = true,
 
-	--- Enable horizontal scrolling
-	--- When true, the plugin will center text horizontally as well as vertically.
-	--- @type boolean
-	enable_horizontal_scroll = true,
+        --- Enable horizontal scrolling
+        --- When true, the plugin will center text horizontally as well as vertically.
+        --- @type boolean
+        enable_horizontal_scroll = true,
+
+        --- Start Typewriter mode on startup
+        --- When true, the plugin enables typewriter mode immediately when setup() is called.
+        --- @type boolean
+        start_enabled = false,
 
 }
 

--- a/lua/typewriter/init.lua
+++ b/lua/typewriter/init.lua
@@ -37,9 +37,13 @@ M.setup = function(user_config)
         config = require("typewriter.config")
 
         autocommands = require("typewriter.autocommands")
+        local commands = require("typewriter.commands")
 
         config.config_setup(user_config or {})
         autocommands.autocmd_setup()
+        if config.config.start_enabled then
+                commands.enable_typewriter_mode()
+        end
         require("typewriter.utils").notify("Typewriter.nvim started")
         logger.info("Typewriter.nvim started")
 end

--- a/tests/logger_spec.lua
+++ b/tests/logger_spec.lua
@@ -59,6 +59,13 @@ describe('typewriter.logger', function()
     assert.is_not_nil(content:find('Typewriter.nvim started'))
   end)
 
+  it('enables typewriter mode when start_enabled is true', function()
+    local typewriter = require('typewriter')
+    typewriter.setup({ start_enabled = true })
+    local utils = require('typewriter.utils')
+    assert.is_true(utils.is_typewriter_active())
+  end)
+
   it('logs fallback warning when regex search is used', function()
     local autocmd = nil
     require('typewriter.autocommands').autocmd_setup()


### PR DESCRIPTION
## 🚀 Pull Request Overview

### Description

Adds a new `start_enabled` configuration option allowing Typewriter.nvim to enable itself automatically on startup. This resolves issue #29 by providing a built‑in way to start the plugin without additional autocmds.

### Changes
- added `start_enabled` to default configuration
- activated typewriter mode in `setup()` when option is true
- documented the option in help docs, README, and CHANGELOG
- added tests verifying the mode starts with the new option

### Testing
- `luacheck lua`
- `busted -v spec`
- `busted -v tests`


------
https://chatgpt.com/codex/tasks/task_e_684fb7e5417883208d8d2ebe7d3bedf5