### PR TITLE
Fix issue #44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.7.4](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.7.4) (2025-07-05)
+- fix(autocommands): restore column preservation after search (issue #44)
+- feat(autocommands): enable preservation for Zen Mode and True Zen events
+- docs: clarify column preservation behavior
+- test: add coverage for search state handling
+
 ## [v0.7.3](https://github.com/joshuadanpeterson/typewriter.nvim/tree/v0.7.3) (2025-06-19)
 - Merge pull request #43 from joshuadanpeterson/codex/fix-issue-#42-based-on-suggestion
 - test: 🧪 restore filetype in commands test

--- a/doc/typewriter.txt
+++ b/doc/typewriter.txt
@@ -70,6 +70,7 @@ User commands created:
 - TWTop: Move the top of the current code block to the top of the screen
 - TWBottom: Move the bottom of the current code block to the bottom of the screen
 - TWPreserveColumn: Toggle column preservation mode
+  Column preservation automatically resumes after search when Typewriter mode remains active.
 
 @usage require("typewriter.autocommands").autocmd_setup()
 

--- a/lua/typewriter/autocommands.lua
+++ b/lua/typewriter/autocommands.lua
@@ -66,13 +66,17 @@ end
 
 -- Function to handle search completion
 local function handle_search_completion()
-	if vim.fn.mode() == "n" then
-		set_state(State.NORMAL)
-		if vim.v.hlsearch == 1 then
-			local search_pattern = vim.fn.getreg("/")
-			move_cursor_to_combined_match(search_pattern)
-		end
-	end
+        if vim.fn.mode() == "n" then
+                if utils.is_typewriter_active() then
+                        set_state(State.PRESERVE_COLUMN)
+                else
+                        set_state(State.NORMAL)
+                end
+                if vim.v.hlsearch == 1 then
+                        local search_pattern = vim.fn.getreg("/")
+                        move_cursor_to_combined_match(search_pattern)
+                end
+        end
 end
 
 --- Move cursor to the best match found using Treesitter and LSP
@@ -321,13 +325,14 @@ function M.autocmd_setup()
 	-- ZenMode and True Zen integration (same as before)
 	-- Autocommands for ZenMode integration
 	if config.config.enable_with_zen_mode then
-		vim.api.nvim_create_autocmd("User", {
-			pattern = "ZenModePre",
-			callback = function()
-				commands.enable_typewriter_mode()
-			end,
-			desc = "Enable Typewriter mode when entering Zen Mode",
-		})
+                vim.api.nvim_create_autocmd("User", {
+                        pattern = "ZenModePre",
+                        callback = function()
+                                commands.enable_typewriter_mode()
+                                set_state(State.PRESERVE_COLUMN)
+                        end,
+                        desc = "Enable Typewriter mode when entering Zen Mode",
+                })
 		vim.api.nvim_create_autocmd("User", {
 			pattern = "ZenModeLeave",
 			callback = function()
@@ -343,6 +348,7 @@ function M.autocmd_setup()
                         pattern = "TZWoon",
                         callback = function()
                                 commands.enable_typewriter_mode()
+                                set_state(State.PRESERVE_COLUMN)
                         end,
                         desc = "Enable Typewriter mode when entering True Zen",
                 })
@@ -361,6 +367,22 @@ function M.autocmd_setup()
                         logger.info("Typewriter.nvim shutdown")
                 end,
         })
+end
+
+--- Enable column preservation state
+function M.enable_column_preservation()
+        set_state(State.PRESERVE_COLUMN)
+end
+
+--- Disable column preservation state
+function M.disable_column_preservation()
+        set_state(State.NORMAL)
+end
+
+--- Get the current internal state (for testing)
+-- @return number current state
+function M.get_state()
+        return current_state
 end
 
 return M

--- a/lua/typewriter/init.lua
+++ b/lua/typewriter/init.lua
@@ -43,6 +43,7 @@ M.setup = function(user_config)
         autocommands.autocmd_setup()
         if config.config.start_enabled then
                 commands.enable_typewriter_mode()
+                autocommands.enable_column_preservation()
         end
         require("typewriter.utils").notify("Typewriter.nvim started")
         logger.info("Typewriter.nvim started")

--- a/tests/autocommands_spec.lua
+++ b/tests/autocommands_spec.lua
@@ -12,3 +12,45 @@ describe('typewriter.autocommands scope', function()
     assert.is_nil(_G.move_cursor_to_regex_match)
   end)
 end)
+
+describe('typewriter.autocommands search state', function()
+  before_each(function()
+    _G.created_autocmds = {}
+    vim.api.nvim_create_autocmd = function(event, opts)
+      table.insert(_G.created_autocmds, { event = event, callback = opts.callback })
+    end
+    vim.fn.mode = function() return 'n' end
+    vim.v = { hlsearch = 1 }
+    vim.fn.getreg = function() return 'foo' end
+    vim.api.nvim_get_current_buf = function() return 1 end
+    vim.api.nvim_buf_get_lines = function() return { 'foo' } end
+    vim.api.nvim_win_set_cursor = function() end
+    package.loaded['typewriter.autocommands'] = nil
+  end)
+
+  after_each(function()
+    _G.created_autocmds = nil
+  end)
+
+  it('restores column preservation after search', function()
+    local autocmds = require('typewriter.autocommands')
+    local utils = require('typewriter.utils')
+
+    autocmds.autocmd_setup()
+
+    local enter_cb, leave_cb
+    for _, ac in ipairs(_G.created_autocmds) do
+      if ac.event == 'CmdlineEnter' then enter_cb = ac.callback end
+      if ac.event == 'CmdlineLeave' then leave_cb = ac.callback end
+    end
+
+    utils.set_typewriter_active(true)
+    autocmds.enable_column_preservation()
+    local preserve_state = autocmds.get_state()
+
+    enter_cb()
+    leave_cb()
+
+    assert.are.equal(preserve_state, autocmds.get_state())
+  end)
+end)


### PR DESCRIPTION
## Summary
- restore column preservation after search
- set state when enabling via Zen Mode or True Zen
- export helpers for column state and use them on startup
- clarify help docs and changelog
- add regression test

## Testing
- `luacheck lua tests spec`
- `busted -v spec`
- `busted -v tests`


------
https://chatgpt.com/codex/tasks/task_e_6869bae719e48320ade41eb6ba468010