### PR TITLE
fix(treesitter): support nvim-treesitter main

### DIFF
--- a/lua/typewriter/autocommands.lua
+++ b/lua/typewriter/autocommands.lua
@@ -6,8 +6,7 @@
 
 local config = require("typewriter.config")
 local commands = require("typewriter.commands")
-local ts_utils = require('nvim-treesitter.ts_utils')
-local ts_parsers = require('nvim-treesitter.parsers')
+local treesitter = require('typewriter.treesitter')
 local utils = require('typewriter.utils')
 local logger = require('typewriter.logger')
 
@@ -111,12 +110,12 @@ end
 --- @param search_pattern string Search pattern
 --- @return table|nil Cursor position
 get_treesitter_match = function(bufnr, search_pattern)
-	local lang = ts_parsers.get_buf_lang(bufnr)
+	local lang = treesitter.get_buf_lang(bufnr)
 	if not lang then
 		return nil
 	end
 
-	local root = ts_utils.get_root_for_position(0, 0, bufnr)
+	local root = treesitter.get_root(bufnr)
 	if not root then
 		return nil
 	end
@@ -144,7 +143,7 @@ get_treesitter_match = function(bufnr, search_pattern)
 	local cursor_position
 	query:for_each_match(root, bufnr, 0, function(_, match, _)
 		for _, node in ipairs(match) do
-			local node_text = ts_utils.get_node_text(node, bufnr)[1]
+			local node_text = treesitter.get_node_text(node, bufnr)
 			if node_text then
 				-- Find the exact position of the match within the node
 				local start_pos = node_text:find(regex_pattern)

--- a/lua/typewriter/commands.lua
+++ b/lua/typewriter/commands.lua
@@ -8,11 +8,11 @@
 --- @tag typewriter-commands
 
 local api = vim.api
-local ts_utils = require("nvim-treesitter.ts_utils")
 local utils = require("typewriter.utils")
 local config = require("typewriter.config")
 local center_block_config = require("typewriter.utils.center_block_config")
 local logger = require("typewriter.logger")
+local treesitter = require("typewriter.treesitter")
 
 local M = {}
 local typewriter_active = false
@@ -154,7 +154,7 @@ end
 --- @usage require("typewriter.commands").center_block_and_cursor()
 --- Center the current code block and cursor
 function M.center_block_and_cursor()
-	local node = ts_utils.get_node_at_cursor()
+	local node = treesitter.get_node_at_cursor()
 	if not node then
 		return
 	end
@@ -204,7 +204,7 @@ end
 ---
 --- @usage require("typewriter.commands").move_to_top_of_block()
 function M.move_to_top_of_block()
-	local node = ts_utils.get_node_at_cursor()
+	local node = treesitter.get_node_at_cursor()
 	if not node then
 		return
 	end
@@ -241,7 +241,7 @@ end
 ---
 --- @usage require("typewriter.commands").move_to_bottom_of_block()
 function M.move_to_bottom_of_block()
-	local node = ts_utils.get_node_at_cursor()
+	local node = treesitter.get_node_at_cursor()
 	if not node then
 		return
 	end

--- a/lua/typewriter/treesitter.lua
+++ b/lua/typewriter/treesitter.lua
@@ -1,0 +1,117 @@
+--- Tree-sitter compatibility helpers for Typewriter.nvim.
+---
+--- Prefer Neovim's built-in Tree-sitter API and fall back to legacy
+--- nvim-treesitter.ts_utils when users are on older nvim-treesitter releases.
+
+local M = {}
+
+local function get_legacy_ts_utils()
+	local ok, ts_utils = pcall(require, "nvim-treesitter.ts_utils")
+	if ok then
+		return ts_utils
+	end
+	return nil
+end
+
+local function get_legacy_parsers()
+	local ok, parsers = pcall(require, "nvim-treesitter.parsers")
+	if ok then
+		return parsers
+	end
+	return nil
+end
+
+local function get_filetype(bufnr)
+	if vim.api.nvim_get_option_value then
+		local ok, ft = pcall(vim.api.nvim_get_option_value, "filetype", { buf = bufnr })
+		if ok and ft ~= "" then
+			return ft
+		end
+	end
+
+	if vim.api.nvim_buf_get_option then
+		local ok, ft = pcall(vim.api.nvim_buf_get_option, bufnr, "filetype")
+		if ok and ft ~= "" then
+			return ft
+		end
+	end
+
+	return vim.bo.filetype
+end
+
+function M.get_buf_lang(bufnr)
+	local parsers = get_legacy_parsers()
+	if parsers and parsers.get_buf_lang then
+		local ok, lang = pcall(parsers.get_buf_lang, bufnr)
+		if ok and lang then
+			return lang
+		end
+	end
+
+	if vim.treesitter and vim.treesitter.language and vim.treesitter.language.get_lang then
+		local ft = get_filetype(bufnr)
+		if ft and ft ~= "" then
+			return vim.treesitter.language.get_lang(ft)
+		end
+	end
+
+	return nil
+end
+
+function M.get_node_at_cursor()
+	if vim.treesitter and vim.treesitter.get_node then
+		local ok, node = pcall(vim.treesitter.get_node, { bufnr = 0 })
+		if ok and node then
+			return node
+		end
+	end
+
+	local ts_utils = get_legacy_ts_utils()
+	if ts_utils and ts_utils.get_node_at_cursor then
+		return ts_utils.get_node_at_cursor()
+	end
+
+	return nil
+end
+
+function M.get_root(bufnr)
+	local lang = M.get_buf_lang(bufnr)
+	if lang and vim.treesitter and vim.treesitter.get_parser then
+		local ok, parser = pcall(vim.treesitter.get_parser, bufnr, lang)
+		if ok and parser then
+			local parsed, trees = pcall(parser.parse, parser)
+			if parsed and trees and trees[1] then
+				return trees[1]:root()
+			end
+		end
+	end
+
+	local ts_utils = get_legacy_ts_utils()
+	if ts_utils and ts_utils.get_root_for_position then
+		return ts_utils.get_root_for_position(0, 0, bufnr)
+	end
+
+	return nil
+end
+
+function M.get_node_text(node, bufnr)
+	if vim.treesitter and vim.treesitter.get_node_text then
+		local ok, text = pcall(vim.treesitter.get_node_text, node, bufnr)
+		if ok then
+			return text
+		end
+	end
+
+	local ts_utils = get_legacy_ts_utils()
+	if ts_utils and ts_utils.get_node_text then
+		local text = ts_utils.get_node_text(node, bufnr)
+		if type(text) == "table" then
+			return text[1]
+		end
+		return text
+	end
+
+	return nil
+end
+
+return M

--- a/tests/treesitter_spec.lua
+++ b/tests/treesitter_spec.lua
@@ -1,0 +1,45 @@
+require('spec.spec_helper')
+
+describe('typewriter.treesitter compatibility', function()
+  before_each(function()
+    package.loaded['typewriter.treesitter'] = nil
+    package.loaded['typewriter.commands'] = nil
+    package.loaded['typewriter.autocommands'] = nil
+    package.loaded['nvim-treesitter.ts_utils'] = nil
+  end)
+
+  it('loads commands without legacy nvim-treesitter.ts_utils', function()
+    local original_require = require
+    _G.require = function(name)
+      if name == 'nvim-treesitter.ts_utils' then
+        error("module 'nvim-treesitter.ts_utils' not found")
+      end
+      return original_require(name)
+    end
+
+    local ok, commands = pcall(original_require, 'typewriter.commands')
+
+    _G.require = original_require
+
+    assert.is_true(ok)
+    assert.is_table(commands)
+  end)
+
+  it('falls back to legacy ts_utils when core get_node is unavailable', function()
+    local legacy_node = { type = function() return 'function' end }
+    package.loaded['nvim-treesitter.ts_utils'] = {
+      get_node_at_cursor = function()
+        return legacy_node
+      end,
+    }
+
+    local original_treesitter = vim.treesitter
+    vim.treesitter = {}
+
+    local treesitter = require('typewriter.treesitter')
+
+    assert.are.equal(legacy_node, treesitter.get_node_at_cursor())
+
+    vim.treesitter = original_treesitter
+  end)
+end)


### PR DESCRIPTION
## Summary
- replace direct `nvim-treesitter.ts_utils` imports with a compatibility adapter
- prefer Neovim core Tree-sitter APIs while keeping legacy fallback support
- add regression coverage for loading without legacy `ts_utils`

## Verification
- `busted`
- `busted tests`
- headless Neovim smoke with current nvim-treesitter runtime and no `ts_utils`
- headless Neovim smoke with core Tree-sitter only

Fixes #50